### PR TITLE
Update FLT2DBL to handle a nil in_array

### DIFF
--- a/example/adx.rb
+++ b/example/adx.rb
@@ -1,0 +1,26 @@
+require 'rubygems'
+require 'talib_ruby'
+
+# init input data
+a = Array.new
+10.times { |i| a.push i.to_f }
+
+h = (7..17).inject([]) { |list, i| list << i }
+l = (3..15).inject([]) { |list, i| list << i }
+c = (6..16).inject([]) { |list, i| list << i }
+
+5.times do |k|
+
+  b = Array.new(10)
+  l = TaLib::Function.new("ADX")
+  # setup input price
+  # open = nil, volume = nil, open_interest = nil
+  l.in_price(0, nil, h, l, c, nil, nil);
+	# setup optional parameter
+	l.opt_int(0,k+2);
+  # setup output parameter
+  l.out_real(0,b);
+  l.call(0,9)
+	p "k=#{k+2}"
+  p b
+end

--- a/ext/talib/talib.c
+++ b/ext/talib/talib.c
@@ -104,6 +104,8 @@ static double* FLT2DBL(double **dest, VALUE in_array)
 	VALUE *inp;
 	int i;
 
+  if NIL_P(in_array) return 0;
+
 	inp = RARRAY_PTR(in_array);
     if (*dest) free(*dest);  // only on 1st use do we skip this step
 	*dest = calloc(1, sizeof(double) * RARRAY_LEN(in_array));
@@ -313,7 +315,16 @@ static VALUE ta_func_setup_in_price(VALUE self, VALUE param_index, VALUE in_open
 	ParamHolder *param_holder;
     Data_Get_Struct(self, ParamHolder, param_holder);
     double **dp = param_holder->in;
-    ret_code = TA_SetInputParamPricePtr( param_holder->p, FIX2INT(param_index), FLT2DBL(&dp[0], in_open), FLT2DBL(&dp[1], in_high), FLT2DBL(&dp[2], in_low), FLT2DBL(&dp[3], in_close), FLT2DBL(&dp[4], in_volume), FLT2DBL(&dp[5], in_oi));
+    
+    ret_code = TA_SetInputParamPricePtr( 
+        param_holder->p, 
+        FIX2INT(param_index), 
+        FLT2DBL(&dp[0], in_open), 
+        FLT2DBL(&dp[1], in_high), 
+        FLT2DBL(&dp[2], in_low), 
+        FLT2DBL(&dp[3], in_close), 
+        FLT2DBL(&dp[4], in_volume), 
+        FLT2DBL(&dp[5], in_oi));
 	if ( ret_code != TA_SUCCESS )
 		rb_raise(rb_eRuntimeError, "unsuccess return code TA_SetInputParamPricePtr");
 }


### PR DESCRIPTION
I've added a change to the FLT2DBL function to return 0 when the input in_array is nil. The function will attempt to manipulate the null pointer otherwise.

This change is necessary because when FLT2DBL is called from ta_func_setup_in_price() it is valid for some of the price inputs to be nil. For example the ADX indicator only requires the high, low, and close price inputs to be set.

The TA-Lib abstract interface function TA_SetInputParamPricePtr called by this function handles the case where the non-required inputs are null.

I've also added an example that demonstrates the use of an indicator that takes a combination of arrays and nil as price inputs.
