### PR TITLE
Support both "ta_lib" and "ta-lib" naming conventions

### DIFF
--- a/ext/talib/extconf.rb
+++ b/ext/talib/extconf.rb
@@ -2,5 +2,6 @@ require 'mkmf'
 
 dir_config("talib")
 
-have_library("ta_lib", "TA_Initialize")
+have_library("ta_lib", "TA_Initialize") || have_library("ta-lib", "TA_Initialize")
+
 create_makefile("talib")


### PR DESCRIPTION
https://github.com/TA-Lib/ta-lib/blob/main/CHANGELOG.md#changed-1
> Static/Shared lib file names uses hyphen instead of underscore. This was needed for some package naming convention. In other word, look for "ta-lib" instead of "ta_lib".